### PR TITLE
wscript: store fordurl

### DIFF
--- a/wscript
+++ b/wscript
@@ -369,6 +369,8 @@ def set_variant_flags(conf):
     # * 'double': promote default reals to double precision
     # * 'openmp': enable OpenMP
 
+    conf.env.fordurl_tem = 'https://geb.inf.tu-dresden.de/doxy/treelm/'
+
     omp_flags = fcopts[conf.env.FC_NAME, 'noomp']
     conf.env.flag_fixform = fcopts[conf.env.FC_NAME, 'fixform']
     if conf.options.openmp:


### PR DESCRIPTION
Register the fordurl in the build environment for later reference by projects that make use of treelm and want to refer to its online location to access its module definitions in constructing the documentation with FORD.