### PR TITLE
aux: vectorial aotus error handler

### DIFF
--- a/source/tem_aux_module.f90
+++ b/source/tem_aux_module.f90
@@ -72,6 +72,11 @@ module tem_aux_module
   public :: check_mpi_error
   public :: check_aot_error
 
+  interface check_aot_error
+    module procedure check_aot_error_scalar
+    module procedure check_aot_error_vector
+  end interface check_aot_error
+
 
 contains
 
@@ -661,7 +666,7 @@ contains
   !! from the Lua script with aot_get_val.
   !!
   !! If a fatal error was encountered, the routine aborts the program!
-  subroutine check_aot_error( iError, key, event_string )
+  subroutine check_aot_error_scalar( iError, key, event_string )
     !> aoterr code to interpret (returned by aot_get_val)
     integer, intent(in) :: iError
     !> Lua key that was attempted to be read
@@ -684,7 +689,46 @@ contains
       write(logUnit(0),*) 'Aborting... '
       call tem_abort()
     end if
-  end subroutine check_aot_error
+  end subroutine check_aot_error_scalar
+  ! ------------------------------------------------------------------------ !
+  ! ------------------------------------------------------------------------ !
+
+
+  ! ------------------------------------------------------------------------ !
+  !> Auxiliary subroutine to check on errors from attempting to get an array
+  !! of values from the Lua script with aot_get_val.
+  !!
+  !! If a fatal error was encountered, the routine aborts the program!
+  subroutine check_aot_error_vector( iError, key, event_string )
+    !> aoterr code to interpret (returned by aot_get_val)
+    integer, intent(in) :: iError(:)
+    !> Lua key that was attempted to be read
+    character(len=*), intent(in) :: key
+    !> Optional event string to describe the circumstances
+    character(len=*), intent(in), optional :: event_string
+
+    integer :: iComp
+
+    if (any(btest(iError, aoterr_Fatal))) then
+      if (present(event_string)) then
+        write(logUnit(0),*) 'Lua Error while ' // trim(event_string) // '!'
+      else
+        write(logUnit(0),*) 'Encountered Lua Error for ' // trim(key) // '!'
+      end if
+      do iComp=lbound(iError,1),ubound(iError,1)
+        if (btest(iError(iComp), aoterr_NonExistent)) then
+          write(logUnit(0),"(a,i0,a)") ' -> expected value "'//trim(key)//'[', &
+            &                        iComp, ']" not found!'
+        end if
+        if (btest(iError(iComp), aoterr_WrongType)) then
+          write(logUnit(0),"(a,i0,a)") ' -> value "'//trim(key)//'[', iComp, &
+            &                        ']" has wrong type!'
+        end if
+      end do
+      write(logUnit(0),*) 'Aborting... '
+      call tem_abort()
+    end if
+  end subroutine check_aot_error_vector
 
 end module tem_aux_module
 ! ---------------------------------------------------------------------------- !


### PR DESCRIPTION
Add a check_aot_error routine for vectorial quantities.
This may be used to deal with errors that occur during
loading a vectorial quantity from the Lua script.
