### PR TITLE
Introduce timeformatter for output files

### DIFF
--- a/doc_pages/features/tracking.md
+++ b/doc_pages/features/tracking.md
@@ -52,6 +52,9 @@ Writes all participating elements to a treelm mesh and creates for each
 required time step a restart file. The output is done in `vtk` and `pvd` files
 that can be visualised with `Paraview`.
 
+It is also possible to configure the format for the timestamp to be
+used in the filenames, see [[tem_timeformatter_load]].
+
 This is a scalable tracking object which works regardless of number of 
 processes.
 

--- a/source/control/tem_time_module.f90
+++ b/source/control/tem_time_module.f90
@@ -1,6 +1,6 @@
 ! Copyright (c) 2012-2013 Manuel Hasert <m.hasert@grs-sim.de>
 ! Copyright (c) 2012-2013 Simon Zimny <s.zimny@grs-sim.de>
-! Copyright (c) 2012-2014, 2017, 2019-2020 Harald Klimach <harald.klimach@uni-siegen.de>
+! Copyright (c) 2012-2014, 2017, 2019-2020, 2025 Harald Klimach <harald.klimach@dlr.de>
 ! Copyright (c) 2013-2014 Kartik Jain <kartik.jain@uni-siegen.de>
 ! Copyright (c) 2013-2014 Kannan Masilamani <kannan.masilamani@uni-siegen.de>
 ! Copyright (c) 2014, 2016 Peter Vitt <peter.vitt2@uni-siegen.de>
@@ -779,7 +779,7 @@ contains
     type(tem_time_type), intent(in) :: time
 
     !> String representation of the given simulation time.
-    character(len=12) :: timeStamp
+    character(len=labelLen) :: timeStamp
     ! -------------------------------------------------------------------- !
     ! -------------------------------------------------------------------- !
 

--- a/source/control/tem_time_module.f90
+++ b/source/control/tem_time_module.f90
@@ -102,8 +102,6 @@ module tem_time_module
   public :: max
 
   public :: tem_time_needs_reduce
-  public :: tem_time_sim_stamp
-  public :: tem_time_iter_stamp
 
   !> Number of available different time definitions.
   integer, parameter, public :: tem_time_n_ids = 3
@@ -764,56 +762,6 @@ contains
       &           .or. (me%clock < huge(me%clock)) )
 
   end function tem_time_isDefined
-  ! ************************************************************************ !
-
-
-  ! ************************************************************************ !
-  !> Generate a time stamp from the simulation time in the given time
-  !! definition.
-  !!
-  !! This basically generates a string identifying the solution time and
-  !! writing it in a meaningful format, so that it can be easily recognized.
-  function tem_time_sim_stamp(time) result(timeStamp)
-    ! -------------------------------------------------------------------- !
-    !> Time definition to create the stamp off.
-    type(tem_time_type), intent(in) :: time
-
-    !> String representation of the given simulation time.
-    character(len=labelLen) :: timeStamp
-    ! -------------------------------------------------------------------- !
-    ! -------------------------------------------------------------------- !
-
-    write(timeStamp, '(EN12.3)') time%sim
-
-    ! remove leading empty spaces in the timestamp
-    timeStamp = adjustl(timeStamp)
-
-  end function  tem_time_sim_stamp
-  ! ************************************************************************ !
-
-
-  ! ************************************************************************ !
-  !> Generate a time stamp from the iteration in the given time
-  !! definition.
-  !!
-  !! This basically generates a string identifying the solution time and
-  !! writing it in a meaningful format, so that it can be easily recognized.
-  function tem_time_iter_stamp(time) result(timeStamp)
-    ! -------------------------------------------------------------------- !
-    !> Time definition to create the stamp off.
-    type(tem_time_type), intent(in) :: time
-
-    !> String representation of the given simulation time.
-    character(len=labelLen) :: timeStamp
-    ! -------------------------------------------------------------------- !
-    ! -------------------------------------------------------------------- !
-
-    write(timeStamp, '(I0)') time%iter
-
-    ! remove leading empty spaces in the timestamp
-    timeStamp = adjustl(timeStamp)
-
-  end function  tem_time_iter_stamp
   ! ************************************************************************ !
 
 end module tem_time_module

--- a/source/control/tem_timeformatter_module.f90
+++ b/source/control/tem_timeformatter_module.f90
@@ -43,6 +43,7 @@ module tem_timeformatter_module
 
   public :: tem_timeformatter_type
   public :: tem_timeformatter_load
+  public :: tem_timeformatter_init
 
   character(len=8), parameter :: default_form = '(EN12.3)'
 
@@ -62,6 +63,35 @@ module tem_timeformatter_module
 
 
 contains
+
+
+  ! ************************************************************************ !
+  !> Reading a timeformatter description from a Lua script given by conf.
+  !!
+  !! Initializing a timeformatter
+  !! * timeform defines the formatting string to be used for the timestamp
+  !!   this defaults to `default_form`
+  !! * stamp defines the routine to use for the timestamp generation and
+  !!   defaults to `tem_timeformatter_sim_stamp`
+  function tem_timeformatter_init(timeform, stamp) result(formatter)
+    character(len=*), optional, intent(in) :: timeform
+    procedure(timestamp), optional :: stamp
+    type(tem_timeformatter_type) :: formatter
+
+    if (present(timeform)) then
+      formatter%timeform = timeform
+    else
+      formatter%timeform = default_form
+    end if
+
+    if (present(stamp)) then
+      formatter%stamp => stamp
+    else
+      formatter%stamp => tem_timeformatter_sim_stamp
+    end if
+
+  end function tem_timeformatter_init
+  ! ************************************************************************ !
 
 
   ! ************************************************************************ !
@@ -109,6 +139,7 @@ contains
     ! -------------------------------------------------------------------- !
     integer :: iErr
     character(len=labelLen) :: loc_key
+    character(len=labelLen) :: timeform
     integer :: thandle
     logical :: use_iter
     logical :: loc_iter_default
@@ -144,7 +175,7 @@ contains
 
       call aot_get_val(L       = conf,         &
         &              thandle = thandle,      &
-        &              val     = me%timeform,  &
+        &              val     = timeform,     &
         &              key     = 'simform',    &
         &              default = default_form, &
         &              ErrCode = iErr          )
@@ -155,7 +186,7 @@ contains
       call aot_get_val(L       = conf,         &
         &              thandle = parent,       &
         &              key     = loc_key,      &
-        &              val     = me%timeform,  &
+        &              val     = timeform,     &
         &              default = default_form, &
         &              ErrCode = iErr          )
     end if
@@ -163,14 +194,16 @@ contains
     call aot_table_close(conf, thandle)
 
     if (use_iter) then
-      me%timeform = '(I0)'
-      me%stamp => tem_timeformatter_iter_stamp
+      me = tem_timeformatter_init(timeform = '(I0)',                      &
+        &                         stamp    = tem_timeformatter_iter_stamp )
     else
-      me%stamp => tem_timeformatter_sim_stamp
+      me = tem_timeformatter_init(timeform = timeform,                   &
+        &                         stamp    = tem_timeformatter_sim_stamp )
     end if
 
   end subroutine tem_timeformatter_load
   ! ************************************************************************ !
+
 
   ! ************************************************************************ !
   !> Generate a time stamp from the simulation time in the given time

--- a/source/control/tem_timeformatter_module.f90
+++ b/source/control/tem_timeformatter_module.f90
@@ -1,0 +1,225 @@
+! Copyright (c) 2025 Harald Klimach <harald.klimach@dlr.de>
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!
+! 1. Redistributions of source code must retain the above copyright notice, this
+! list of conditions and the following disclaimer.
+!
+! 2. Redistributions in binary form must reproduce the above copyright notice,
+! this list of conditions and the following disclaimer in the documentation
+! and/or other materials provided with the distribution.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+! AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+! IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+! DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+! FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+! DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+! SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+! OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+! OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+! **************************************************************************** !
+!
+!> Formatting of time points.
+!!
+!! The formatters alllow the specification of how time-stamps for given time
+!! objects are to be formatted.
+!!
+module tem_timeformatter_module
+  use env_module, only: labelLen
+
+  use aotus_module, only: flu_State, &
+    &                     aot_get_val
+  use aot_table_module, only: aot_table_open, &
+    &                         aot_table_close
+
+  use tem_time_module, only: tem_time_type
+
+  implicit none
+
+  private
+
+  public :: tem_timeformatter_type
+  public :: tem_timeformatter_load
+
+  character(len=8), parameter :: default_form = '(EN12.3)'
+
+  type tem_timeformatter_type
+    character(len=labelLen) :: timeform = default_form
+    procedure(timestamp), pointer, pass(formatter) :: stamp => null()
+  end type tem_timeformatter_type
+
+  abstract interface
+    function timestamp(formatter, time) result(stamp)
+      import :: tem_time_type, tem_timeformatter_type, labelLen
+      class(tem_timeformatter_type), intent(in) :: formatter
+      type(tem_time_type), intent(in) :: time
+      character(len=LabelLen) :: stamp
+    end function timestamp
+  end interface
+
+
+contains
+
+
+  ! ************************************************************************ !
+  !> Reading a timeformatter description from a Lua script given by conf.
+  !!
+  !! The timeformatter description has to be provided in the table given by
+  !! thandle.
+  !! There are two settings for the formatting:
+  !! - use_iter: use the number of iterations rather than simulated time
+  !!             Default: false, but may be overwritten by caller.
+  !! - simform: Fortran formatting string for the real number of the
+  !!            simulated time.
+  !!            Default: '(EN12.3)'
+  !! Thus, the configuration looks like:
+  !!
+  !! \verbatim
+  !! timeformat = { use_iter = false, simform = '(EN12.3)' }
+  !! \end verbatim
+  !!
+  !! If timeformat is not a table, the value is attempted to be read as a
+  !! string for the simform, so it is also possible to write:
+  !!
+  !! \verbatim
+  !! timeformat = '(EN15.6)'
+  !! \end verbatim
+  !!
+  !! The key to be used for reading these settings could also be changed by
+  !! the caller by passing the key to be used in the key argument.
+  subroutine tem_timeformatter_load(me, conf, key, parent, use_iter_default)
+    ! -------------------------------------------------------------------- !
+    !> Time to be read from the Lua script
+    type(tem_timeformatter_type), intent(out) :: me
+
+    !> Handle to the Lua script.
+    type(flu_state), intent(inout) :: conf
+
+    !> Name of the table containing the time definition. Default: 'time'.
+    character(len=*), intent(in), optional :: key
+
+    !> Handle to the parent table.
+    integer, intent(in), optional :: parent
+
+    !> Default for the use_iter setting
+    logical, intent(in), optional :: use_iter_default
+    ! -------------------------------------------------------------------- !
+    integer :: iErr
+    character(len=labelLen) :: loc_key
+    integer :: thandle
+    logical :: use_iter
+    logical :: loc_iter_default
+    ! -------------------------------------------------------------------- !
+
+    if ( present(key) ) then
+      loc_key = trim(key)
+    else
+      loc_key = 'timeformat'
+    end if
+
+    if ( present(use_iter_default) ) then
+      loc_iter_default = use_iter_default
+    else
+      loc_iter_default = .false.
+    end if
+
+    call aot_table_open(L       = conf,    &
+      &                 parent  = parent,  &
+      &                 thandle = thandle, &
+      &                 key     = loc_key  )
+
+    use_iter = loc_iter_default
+
+    if (thandle /= 0) then
+      ! The timeformat is given as a table load its components accordingly.
+      call aot_get_val(L       = conf,             &
+        &              thandle = thandle,          &
+        &              val     = use_iter,         &
+        &              key     = 'use_iter',       &
+        &              default = loc_iter_default, &
+        &              ErrCode = iErr              )
+
+      call aot_get_val(L       = conf,         &
+        &              thandle = thandle,      &
+        &              val     = me%timeform,  &
+        &              key     = 'simform',    &
+        &              default = default_form, &
+        &              ErrCode = iErr          )
+
+    else
+      ! The time is not given as a table, try to interpret it as a setting for
+      ! the simform.
+      call aot_get_val(L       = conf,         &
+        &              thandle = parent,       &
+        &              key     = loc_key,      &
+        &              val     = me%timeform,  &
+        &              default = default_form, &
+        &              ErrCode = iErr          )
+    end if
+
+    call aot_table_close(conf, thandle)
+
+    if (use_iter) then
+      me%timeform = '(I0)'
+      me%stamp => tem_timeformatter_iter_stamp
+    else
+      me%stamp => tem_timeformatter_sim_stamp
+    end if
+
+  end subroutine tem_timeformatter_load
+  ! ************************************************************************ !
+
+  ! ************************************************************************ !
+  !> Generate a time stamp from the simulation time in the given time
+  !! definition.
+  !!
+  !! This basically generates a string identifying the solution time and
+  !! writing it in a meaningful format, so that it can be easily recognized.
+  function tem_timeformatter_sim_stamp(formatter, time) result(timeStamp)
+    ! -------------------------------------------------------------------- !
+    !> Formatting object to generate the time stamp
+    class(tem_timeformatter_type), intent(in) :: formatter
+    !> Time definition to create the stamp off.
+    type(tem_time_type), intent(in) :: time
+
+    !> String representation of the given simulation time.
+    character(len=labelLen) :: timeStamp
+    ! -------------------------------------------------------------------- !
+    ! -------------------------------------------------------------------- !
+
+    write(timeStamp, formatter%timeform) time%sim
+
+    ! remove leading empty spaces in the timestamp
+    timeStamp = adjustl(timeStamp)
+
+  end function  tem_timeformatter_sim_stamp
+  ! ************************************************************************ !
+
+
+  ! ************************************************************************ !
+  !> Generate a time stamp from the iteration in the given time
+  !! definition.
+  function tem_timeformatter_iter_stamp(formatter, time) result(timeStamp)
+    ! -------------------------------------------------------------------- !
+    !> Formatting object to generate the time stamp
+    class(tem_timeformatter_type), intent(in) :: formatter
+    !> Time definition to create the stamp off.
+    type(tem_time_type), intent(in) :: time
+
+    !> String representation of the given simulation time.
+    character(len=labelLen) :: timeStamp
+    ! -------------------------------------------------------------------- !
+    ! -------------------------------------------------------------------- !
+
+    write(timeStamp, formatter%timeform) time%iter
+
+    ! remove leading empty spaces in the timestamp
+    timeStamp = adjustl(timeStamp)
+
+  end function  tem_timeformatter_iter_stamp
+  ! ************************************************************************ !
+
+end module tem_timeformatter_module

--- a/source/libharvesting/hvs_output_module.f90
+++ b/source/libharvesting/hvs_output_module.f90
@@ -40,6 +40,8 @@ module hvs_output_module
   use tem_subtree_type_module,        only: tem_subtree_type, tem_dump_subTree
   use tem_subTree_module,             only: tem_updatePropertyBits
   use tem_time_module,                only: tem_time_type, tem_time_reset
+  use tem_timeformatter_module,       only: tem_timeformatter_type, &
+    &                                       tem_timeformatter_load
   use tem_tools_module,               only: upper_to_lower
   use tem_varsys_module,              only: tem_varsys_type
   use tem_varMap_module,              only: tem_varMap_type, tem_create_varMap
@@ -105,6 +107,9 @@ module hvs_output_module
     !> Kind of visualization file to use for the output.
     integer :: vis_kind
 
+    !> Description how to format timestamps
+    type(tem_timeformatter_type) :: timeform
+
     !> Description of the vtk configuration (used when vis_kind='vtk')
     type(hvs_vtk_config_type) :: vtk
 
@@ -140,6 +145,9 @@ module hvs_output_module
 
     !> Description for harvester output i.e restart format
     type(tem_restart_type) :: restart
+
+    !> Description how to format timestamps
+    type(tem_timeformatter_type) :: timeform
 
     !> Point in time for which this output should be done.
     type(tem_time_type) :: time
@@ -199,9 +207,11 @@ contains
     character(len=labelLen) :: vkind
     integer :: thandle
     integer :: iError
+    logical :: use_iter = .false.
     ! ----------------------------------------------------------------------!
     write(logUnit(3), *) '  Loading output table ...'
 
+    use_iter = .false.
     call aot_table_open( L       = conf,    &
       &                  parent  = parent,  &
       &                  thandle = thandle, &
@@ -282,6 +292,15 @@ contains
       call tem_abort()
     end if
     write(logUnit(5),*) '  Output format: '//trim(vkind)
+
+    if (me%vis_kind == hvs_VTK) then
+      use_iter = me%vtk%iter_filename
+    end if
+
+    call tem_timeformatter_load( me               = me%timeform, &
+      &                          conf             = conf,        &
+      &                          parent           = thandle,     &
+      &                          use_iter_default = use_iter     )
 
     ! To decide whether to use get_point or get_element
     call aot_get_val( L       = conf,           &
@@ -378,6 +397,8 @@ contains
     out_file%vis_kind = out_config%vis_kind
 
     out_file%useGetPoint = out_config%useGetPoint
+
+    out_file%timeform = out_config%timeform
 
     ! copy basename
     out_file%basename = trim(basename)
@@ -525,6 +546,7 @@ contains
 
       ! this restart object is not meant to read data!
       out_file%restart%controller%readRestart = .false.
+      out_file%restart%timeform = out_file%timeform
 
       ! create varMap for restart
       call tem_create_varMap(varName = varSys%varName%val(out_file%varPos), &
@@ -569,14 +591,9 @@ contains
   !!
   !! This writes the mesh data to the output files.
   !! Subsequently it can then be enriched by restart information.
-  subroutine hvs_output_open(out_file, use_iter, mesh, varsys, time, subtree )
+  subroutine hvs_output_open(out_file, mesh, varsys, time, subtree )
     ! --------------------------------------------------------------------------!
     type(hvs_output_file_type), intent(inout) :: out_file
-
-    !> The output configuration settings to use.
-    ! type(hvs_output_config_type), intent(in) :: out_config
-    ! Use iteration in filename?
-    logical, intent(in) :: use_iter
 
     !> Mesh of the data to visualize.
     type(treelmesh_type), intent(in) :: mesh
@@ -641,10 +658,10 @@ contains
           &                         varSys = varSys          )
       end if ! present subTree
     case(hvs_VTK)
-      call hvs_vtk_open( vtk_file = out_file%vtk,   &
-        &                use_iter = use_iter,       &
-        &                proc     = out_file%proc,  &
-        &                time     = out_file%time   )
+      call hvs_vtk_open( vtk_file = out_file%vtk,      &
+        &                timeform = out_file%timeform, &
+        &                proc     = out_file%proc,     &
+        &                time     = out_file%time      )
 
       call hvs_vtk_write_meshdata( vtk_file = out_file%vtk,  &
         &                          vrtx     = out_file%vrtx, &

--- a/source/libharvesting/hvs_output_module.f90
+++ b/source/libharvesting/hvs_output_module.f90
@@ -333,9 +333,9 @@ contains
   !> Initialize the output for a given mesh.
   !!
   !! This creates vertex for a mesh and fill hvs_output_file_type.
-  subroutine hvs_output_init(out_file, out_config, tree, varsys, subtree,      &
-    &                        varPos, basename, timeControl, nDofs, globProc,   &
-    &                        solver, geometry, solSpec_unit)
+  subroutine hvs_output_init(out_file, out_config, tree, varsys, subtree,    &
+    &                        varPos, basename, timeControl, nDofs, globProc, &
+    &                        solver, geometry, solSpec_unit                  )
     ! --------------------------------------------------------------------------!
     !> Output file settings
     !! It must be intent inout since ascii%reduction and trasient%reduction
@@ -535,6 +535,7 @@ contains
         &                         nPoints      = nPoints,               &
         &                         glob_nPoints = glob_nPoints,          &
         &                         timeControl  = timeControl,           &
+        &                         timeform     = out_file%timeform,     &
         &                         solver       = solver,                &
         &                         geometry     = geometry               )
     case(hvs_Internal)

--- a/source/libharvesting/hvs_output_module.f90
+++ b/source/libharvesting/hvs_output_module.f90
@@ -1,7 +1,7 @@
 ! Copyright (c) 2015-2016 Kannan Masilamani <kannan.masilamani@uni-siegen.de>
 ! Copyright (c) 2015-2016 Jiaxing Qi <jiaxing.qi@uni-siegen.de>
 ! Copyright (c) 2016 Tobias Schneider <tobias1.schneider@student.uni-siegen.de>
-! Copyright (c) 2016, 2019 Harald Klimach <harald.klimach@uni-siegen.de>
+! Copyright (c) 2016, 2019, 2025 Harald Klimach <harald.klimach@dlr.de>
 ! Copyright (c) 2016 Nikhil Anand <nikhil.anand@uni-siegen.de>
 !
 ! Redistribution and use in source and binary forms, with or without

--- a/source/libharvesting/hvs_vtk_module.f90
+++ b/source/libharvesting/hvs_vtk_module.f90
@@ -2,7 +2,7 @@
 ! Copyright (c) 2015-2016 Jiaxing Qi <jiaxing.qi@uni-siegen.de>
 ! Copyright (c) 2016, 2019 Peter Vitt <peter.vitt2@uni-siegen.de>
 ! Copyright (c) 2016 Tobias Schneider <tobias1.schneider@student.uni-siegen.de>
-! Copyright (c) 2016, 2021 Harald Klimach <harald.klimach@dlr.de>
+! Copyright (c) 2016, 2021, 2025 Harald Klimach <harald.klimach@dlr.de>
 ! Copyright (c) 2016 Nikhil Anand <nikhil.anand@uni-siegen.de>
 ! Copyright (c) 2018 Raphael Haupt <Raphael.Haupt@student.uni-siegen.de>
 ! Copyright (c) 2021 Jana Gericke <jana.gericke@dlr.de>

--- a/source/libharvesting/hvs_vtk_module.f90
+++ b/source/libharvesting/hvs_vtk_module.f90
@@ -62,6 +62,7 @@ module hvs_vtk_module
   use tem_comm_env_module,     only: tem_comm_env_type
   use tem_logging_module,      only: logunit
   use tem_subtree_type_module, only: tem_subtree_type
+  use tem_timeformatter_module, only: tem_timeformatter_type
   use tem_time_module,         only: tem_time_type,      &
     &                                tem_time_sim_stamp, &
     &                                tem_time_iter_stamp
@@ -225,14 +226,14 @@ contains
   !! We always write unstructured meshes, so we also write the header for the
   !! unstructured mesh here already.
   !! The actual mesh data is then to be written by hvs_vtk_write_meshdata.
-  subroutine hvs_vtk_open(vtk_file, use_iter, proc, time)
+  subroutine hvs_vtk_open(vtk_file, timeform, proc, time)
     !> The file description to open.
     type(hvs_vtk_file_type), intent(inout) :: vtk_file
 
     !> User specified settings for the output
     ! type(hvs_vtk_config_type), intent(in) :: vtk_config
     !> Whether to use iteration as part of filename
-    logical, intent(in) :: use_iter
+    type(tem_timeformatter_type), intent(in) :: timeform
 
     !> Parallel environment to use for  the output.
     type(tem_comm_env_type), intent(in) :: proc
@@ -264,13 +265,8 @@ contains
 
     vtk_file%timestamp = ''
     if (present(time)) then
-      if ( use_iter ) then
-        write(vtk_file%timestamp, '(a)') &
-          & '_t' // trim(tem_time_iter_stamp(time))
-      else
-        write(vtk_file%timestamp, '(a)') &
-          & '_t' // trim(tem_time_sim_stamp(time))
-      end if
+      write(vtk_file%timestamp, '(a)') &
+        & '_t' // trim(timeform%stamp(time))
     end if
 
     write(filename,'(a)') trim(filename) // trim(vtk_file%timestamp) // '.vtu'
@@ -890,11 +886,12 @@ contains
   !!
   !! The caller has to provide the vrtx, which can be created with the
   !! tem_calc_vrtx_coord-routine.
-  subroutine hvs_dump_debug_array( proc, tree, time, vrtx, debug_data)
+  subroutine hvs_dump_debug_array( proc, tree, time, timeform, vrtx, debug_data)
     !---------------------------------------------------------------------------
     type(tem_comm_env_type), intent(in) :: proc
     type(treelmesh_type), intent(in) :: tree
     type(tem_time_type), intent(in) :: time
+    type(tem_timeformatter_type), intent(in) :: timeform
     type(tem_vrtx_type) :: vrtx
     real(kind=rk) :: debug_data(tree%nElems)
     !---------------------------------------------------------------------------
@@ -915,7 +912,7 @@ contains
 
 
     call hvs_vtk_open( vtk_file = vtk_file,   &
-      &                use_iter = .true.,     &
+      &                timeform = timeform,   &
       &                proc     = proc,       &
       &                time     = time        )
 

--- a/source/libharvesting/hvs_vtk_module.f90
+++ b/source/libharvesting/hvs_vtk_module.f90
@@ -63,9 +63,7 @@ module hvs_vtk_module
   use tem_logging_module,      only: logunit
   use tem_subtree_type_module, only: tem_subtree_type
   use tem_timeformatter_module, only: tem_timeformatter_type
-  use tem_time_module,         only: tem_time_type,      &
-    &                                tem_time_sim_stamp, &
-    &                                tem_time_iter_stamp
+  use tem_time_module,         only: tem_time_type
   use tem_tools_module,        only: upper_to_lower
   use tem_varsys_module,       only: tem_varsys_type
   use tem_vrtx_module,         only: tem_vrtx_type
@@ -246,6 +244,7 @@ contains
     ! ----------------------------------------------------------------------!
     character(len=PathLen) :: filename
     character(len=PathLen) :: headerline
+    character(len=LabelLen) :: timestring
     character :: linebreak
     integer :: pos
     character(len=labelLen) :: byte_order
@@ -263,10 +262,12 @@ contains
       write(filename,'(a)') trim(vtk_file%basename)
     end if
 
+    timestring = '0'
     vtk_file%timestamp = ''
     if (present(time)) then
+      timestring = trim(timeform%stamp(time))
       write(vtk_file%timestamp, '(a)') &
-        & '_t' // trim(timeform%stamp(time))
+        & '_t' // trim(timestring)
     end if
 
     write(filename,'(a)') trim(filename) // trim(vtk_file%timestamp) // '.vtu'
@@ -360,7 +361,7 @@ contains
     if ( vtk_file%write_pvd ) then
       pos = INDEX(trim(filename), pathSep, .true.)
       write(headerline,'(a)') '  <DataSet timestep="' &
-        &                     //trim(tem_time_sim_stamp(time))//'" file="' &
+        &                     //trim(timestring)//'" file="' &
         &                     //trim(filename(pos+1:))//'"/>'
       write(vtk_file%pvdunit) trim(headerline)//linebreak
       flush(vtk_file%pvdunit)

--- a/source/tem_restart_module.f90
+++ b/source/tem_restart_module.f90
@@ -115,11 +115,12 @@ module tem_restart_module
     &                                tem_timeControl_load, &
     &                                tem_timeControl_align_trigger, &
     &                                tem_timeControl_dump
-  use tem_time_module,         only: tem_time_sim_stamp, tem_time_type, &
+  use tem_time_module,         only: tem_time_type, &
     &                                tem_time_out, tem_time_load,       &
     &                                tem_time_set_clock, tem_time_dump, &
     &                                tem_time_reset
-  use tem_timeformatter_module, only: tem_timeformatter_type,&
+  use tem_timeformatter_module, only: tem_timeformatter_type, &
+    &                                 tem_timeformatter_init, &
     &                                 tem_timeformatter_load
   use tem_tools_module,        only: tem_horizontalSpacer
   use tem_varSys_module,       only: tem_varSys_type, tem_varSys_out,  &
@@ -1334,6 +1335,7 @@ contains
     integer :: iError
     type( flu_State ) :: conf
     character(len=labelLen) :: buffer
+    type(tem_timeformatter_type) :: timeform
     ! -------------------------------------------------------------------- !
     write(logUnit(1),*) 'Opening Restart Header '         &
       &                 // trim(me%controller%readFileName)
@@ -1386,7 +1388,8 @@ contains
       &                 me          = timing,            &
       &                 clock_start = timing%clock_start )
 
-    me%header%timestamp = trim(tem_time_sim_stamp(timing))
+    timeform = tem_timeformatter_init()
+    me%header%timestamp = trim(timeform%stamp(timing))
     write(logUnit(1),*) 'Restarting from point in time:'
     call tem_time_dump(timing, logUnit(1))
 

--- a/source/tem_restart_module.f90
+++ b/source/tem_restart_module.f90
@@ -3,7 +3,7 @@
 ! Copyright (c) 2011-2012 Jens Zudrop <j.zudrop@grs-sim.de>
 ! Copyright (c) 2011-2016 Kannan Masilamani <kannan.masilamani@uni-siegen.de>
 ! Copyright (c) 2011-2012 Khaled Ibrahim <k.ibrahim@grs-sim.de>
-! Copyright (c) 2011-2019, 2021 Harald Klimach <harald.klimach@dlr.de>
+! Copyright (c) 2011-2019, 2021, 2025 Harald Klimach <harald.klimach@dlr.de>
 ! Copyright (c) 2012, 2014-2016 Jiaxing Qi <jiaxing.qi@uni-siegen.de>
 ! Copyright (c) 2012-2014 Kartik Jain <kartik.jain@uni-siegen.de>
 ! Copyright (c) 2012-2013 Melven Zoellner <yameta@freenet.de>
@@ -119,6 +119,8 @@ module tem_restart_module
     &                                tem_time_out, tem_time_load,       &
     &                                tem_time_set_clock, tem_time_dump, &
     &                                tem_time_reset
+  use tem_timeformatter_module, only: tem_timeformatter_type,&
+    &                                 tem_timeformatter_load
   use tem_tools_module,        only: tem_horizontalSpacer
   use tem_varSys_module,       only: tem_varSys_type, tem_varSys_out,  &
     &                                tem_varSys_load, tem_varSys_dump, &
@@ -258,6 +260,8 @@ module tem_restart_module
     type(tem_restartHeader_type)  :: header
     !> unit integer to write binary data to
     integer :: binaryUnit
+    !> Formatter for the timestamps to be used in file names
+    type(tem_timeformatter_type) :: timeform
     !> name and position of variables in global variable system
     type(tem_varMap_type) :: varMap
     !!> number of scalars of variables in varPos
@@ -283,12 +287,17 @@ contains
   !!                                              -- if any
   !!             write = 'restart/', -- Where to write the restart files to,
   !!                                 -- if any
-  !!             time = { min = 0, max = 10, interval = 10} -- when to output
+  !!             time = { min = 0, max = 10, interval = 10}, -- when to output
+  !!             timeform = { use_iter = false, simform = '(EN12.3)' }
   !!             }
   !!```
   !! Here, the restart is loaded from `restart/lastHeader.lua` and reads in the
   !! related data and configuration.
   !! Restart files are written out in `restart/` folder
+  !! The files will get a timestamp based simulated time in engineering notation
+  !! with three digits as configured in the timeform table.
+  !! This is the default timestamp format and can also be omitted.
+  !! See [[tem_timeformatter_load]].
   !!
   subroutine tem_load_restart( me, conf, tree, timing, globProc, parent_table, &
     &                          key )
@@ -422,6 +431,10 @@ contains
         &               val     = me%controller%writePrefix, &
         &               ErrCode = iError                     )
       me%controller%writeRestart = (iError == 0)
+
+      call tem_timeformatter_load(me     = me%timeform,  &
+        &                         conf   = conf,         &
+        &                         parent = restart_table )
 
       if (me%controller%writeRestart) then
         ! Read the time intervals for restart output from the Lua config.
@@ -1081,7 +1094,7 @@ contains
     ! -------------------------------------------------------------------- !
 
     ! Update the timestamp
-    me%header%timestamp = trim(tem_time_sim_stamp(timing))
+    me%header%timestamp = trim(me%timeform%stamp(timing))
 
     ! Set the iteration to know when the last restart file was written
     me%lastWritten = timing

--- a/source/tem_stlbIO_module.f90
+++ b/source/tem_stlbIO_module.f90
@@ -1,5 +1,5 @@
 ! Copyright (c) 2013-2014 Simon Zimny <s.zimny@grs-sim.de>
-! Copyright (c) 2013-2014, 2019, 2021 Harald Klimach <harald.klimach@dlr.de>
+! Copyright (c) 2013-2014, 2019, 2021, 2025 Harald Klimach <harald.klimach@dlr.de>
 ! Copyright (c) 2016 Tobias Schneider <tobias1.schneider@student.uni-siegen.de>
 ! Copyright (c) 2016 Peter Vitt <peter.vitt2@uni-siegen.de>
 !

--- a/source/tem_stlbIO_module.f90
+++ b/source/tem_stlbIO_module.f90
@@ -219,7 +219,7 @@ contains
     ! error variable
     integer :: iError
     ! timestamp for the filename
-    character(len=12) :: timeStamp
+    character(len=labelLen) :: timeStamp
     ! temporary min and max position for X,Y,Z coordinates in the linearized
     ! array of nodes
     integer :: minPos1, maxPos1, minPos2, maxPos2, minPos3, maxPos3

--- a/source/tem_stlbIO_module.f90
+++ b/source/tem_stlbIO_module.f90
@@ -33,12 +33,14 @@ module tem_stlb_io_module
   ! incude treelm modules
   use mpi
   use env_module,            only: single_k,rk, LabelLen, PathLen, rk_mpi, eps
-  use tem_logging_module,    only: logUnit
   use tem_aux_module,        only: tem_open, tem_abort
-  use tem_math_module,       only: cross_product3D
-  use tem_time_module,       only: tem_time_type, tem_time_sim_stamp
   use tem_comm_env_module,   only: tem_comm_env_type
   use tem_grow_array_module, only: grw_int2darray_type, init, append, destroy
+  use tem_logging_module,    only: logUnit
+  use tem_math_module,       only: cross_product3D
+  use tem_time_module,       only: tem_time_type
+  use tem_timeformatter_module, only: tem_timeformatter_type, &
+    &                                 tem_timeformatter_init
 
   implicit none
 
@@ -186,7 +188,7 @@ contains
   !!        as well)
   !!
   subroutine tem_dump_stlb( outprefix, nodes, triangles, proc, header,   &
-    &                       normals, time )
+    &                       normals, time, timeformatter                 )
     ! --------------------------------------------------------------------------
     !> output prefix for the filename
     character(len=*), intent(in) :: outprefix
@@ -203,7 +205,10 @@ contains
     real(kind=rk), optional, intent(in) :: normals(:,:)
     !> optional simulation time to be appended to the filename
     type(tem_time_type), optional, intent(in) :: time
+    !> optional formatter for the timestamp
+    type(tem_timeformatter_type), optional, intent(in) :: timeformatter
     ! --------------------------------------------------------------------------
+    type(tem_timeformatter_type) :: loc_timeformatter
     real(kind=single_k) :: loc_normals( 3, size( triangles, 2 ))
     integer :: iTria
     ! temporary vectors to calculate the normals
@@ -308,12 +313,17 @@ contains
       ! initialize the attribute to be empty
       attribute = ''
 
-      if( present( time ))then
-        timestamp = adjustl(tem_time_sim_stamp(time))
+      if ( present(time) ) then
+        if (present(timeformatter)) then
+          loc_timeformatter = timeformatter
+        else
+          loc_timeformatter = tem_timeformatter_init()
+        end if
+        timestamp = adjustl(loc_timeformatter%stamp(time))
         ! assemble the filename
-        write(filename,'(a)')trim(outprefix)//'_t'//trim(timestamp)//".stl"
+        write(filename,'(a)') trim(outprefix)//'_t'//trim(timestamp)//".stl"
       else
-        write(filename,'(a)')trim(outprefix)//".stl"
+        write(filename,'(a)') trim(outprefix)//".stl"
       end if
 
       ! open the output file and

--- a/source/tem_tracking_module.f90
+++ b/source/tem_tracking_module.f90
@@ -2,7 +2,7 @@
 ! Copyright (c) 2011 Konstantin Kleinheinz <k.kleinheinz@grs-sim.de>
 ! Copyright (c) 2011-2012, 2014 Jens Zudrop <j.zudrop@grs-sim.de>
 ! Copyright (c) 2011-2013 Manuel Hasert <m.hasert@grs-sim.de>
-! Copyright (c) 2011-2016,2020 Harald Klimach <harald.klimach@uni-siegen.de>
+! Copyright (c) 2011-2016, 2020, 2025 Harald Klimach <harald.klimach@dlr.de>
 ! Copyright (c) 2011 Gaurang Phadke <g.phadke@grs-sim.de>
 ! Copyright (c) 2011 Laura Didinger <l.didinger@grs-sim.de>
 ! Copyright (c) 2011 Jan Hueckelheim <j.hueckelheim@grs-sim.de>

--- a/source/tem_tracking_module.f90
+++ b/source/tem_tracking_module.f90
@@ -897,8 +897,6 @@ module tem_tracking_module
           ! depends on output vis_kind
           call hvs_output_open(                                 &
             &    out_file = track%instance(iLog)%output_file,   &
-            &    use_iter = track%config(iConfig)%output_config &
-            &                    %vtk%iter_filename,            &
             &    mesh     = tree,                               &
             &    varSys   = varSys,                             &
             &    time     = simControl%now                      )
@@ -918,8 +916,6 @@ module tem_tracking_module
           ! depends on output vis_kind
           call hvs_output_open(                                 &
             &    out_file = track%instance(iLog)%output_file,   &
-            &    use_iter = track%config(iConfig)%output_config &
-            &                    %vtk%iter_filename,            &
             &    mesh     = tree,                               &
             &    varSys   = varSys,                             &
             &    subTree  = track%instance(iLog)%subTree,       &


### PR DESCRIPTION
The timeformatter offers the possibility to configure the format
of the timestamps used in filenames for tracking and restart
output files.
